### PR TITLE
optionally use cert manager for mutating web hook certificates

### DIFF
--- a/charts/spark-operator/Chart.yaml
+++ b/charts/spark-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: spark-operator
 description: A Helm chart for Spark on Kubernetes operator
-version: 1.0.5
+version: 1.0.6
 appVersion: v1beta2-1.2.0-3.0.0
 keywords:
   - spark

--- a/charts/spark-operator/templates/certificate.yaml
+++ b/charts/spark-operator/templates/certificate.yaml
@@ -7,8 +7,8 @@ metadata:
     {{- include "spark-operator.labels" . | nindent 4 }}
 spec:
   dnsNames:
-  - "{{ include "spark-operator.fullname" . }}-webhook.{ .Release.Namespace }}.svc"
-  - "{{ include "spark-operator.fullname" . }}-webhook.{ .Release.Namespace }}.svc.cluster.local"
+  - "{{ include "spark-operator.fullname" . }}-webhook.{{ .Release.Namespace }}.svc"
+  - "{{ include "spark-operator.fullname" . }}-webhook.{{ .Release.Namespace }}.svc.cluster.local"
   issuerRef:
     kind: Issuer
     name: "{{ .Values.webhook.certIssuer }}"

--- a/charts/spark-operator/templates/certificate.yaml
+++ b/charts/spark-operator/templates/certificate.yaml
@@ -1,0 +1,16 @@
+{{ if .Values.webhook.useCertManager }}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: "{{ include "spark-operator.fullname" . }}-webhook"
+  labels:
+    {{- include "spark-operator.labels" . | nindent 4 }}
+spec:
+  dnsNames:
+  - "{{ include "spark-operator.fullname" . }}-webhook.{ .Release.Namespace }}.svc"
+  - "{{ include "spark-operator.fullname" . }}-webhook.{ .Release.Namespace }}.svc.cluster.local"
+  issuerRef:
+    kind: Issuer
+    name: "{{ .Values.webhook.certIssuer }}"
+  secretName: spark-webhook-certs
+{{ end }}

--- a/charts/spark-operator/templates/deployment.yaml
+++ b/charts/spark-operator/templates/deployment.yaml
@@ -73,6 +73,11 @@ spec:
         - -webhook-svc-name={{ include "spark-operator.fullname" . }}-webhook
         - -webhook-config-name={{ include "spark-operator.fullname" . }}-webhook-config
         - -webhook-namespace-selector={{ .Values.webhook.namespaceSelector }}
+        {{ if .Values.webhook.useCertManager }}
+        - -webhook-server-cert=/etc/webhook-certs/tls.crt
+        - -webhook-server-cert-key=/etc/webhook-certs/tls.key
+        - -webhook-ca-cert=/etc/webhook-certs/ca.crt
+        {{- end }}
         {{- end }}
         - -enable-resource-quota-enforcement={{ .Values.resourceQuotaEnforcement.enable }}
         {{- if gt (int .Values.replicaCount) 1 }}

--- a/charts/spark-operator/templates/webhook-cleanup-job.yaml
+++ b/charts/spark-operator/templates/webhook-cleanup-job.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.webhook.enable }}
+{{ if .Values.webhook.generateCerts }}
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/charts/spark-operator/templates/webhook-init-job.yaml
+++ b/charts/spark-operator/templates/webhook-init-job.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.webhook.enable }}
+{{ if .Values.webhook.generateCerts }}
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/charts/spark-operator/values.yaml
+++ b/charts/spark-operator/values.yaml
@@ -40,7 +40,7 @@ serviceAccounts:
     name: ""
 
 # -- Set this if running spark jobs in a different namespace than the operator
-sparkJobNamespace: ""
+sparkJobNamespace:
 
 # -- Operator concurrency, higher values might increase memory usage
 controllerThreads: 10
@@ -69,6 +69,12 @@ webhook:
   # -- The webhook server will only operate on namespaces with this label, specified in the form key1=value1,key2=value2.
   # Empty string (default) will operate on all namespaces
   namespaceSelector: ""
+  # use script to generate webhook certs
+  generateCerts: true
+  # use cert-manager to generate webhook certs
+  useCertManager: false
+  # name of cert-manager certificate issuer
+  certIssuer: issuer
 
 metrics:
   # -- Enable prometheus mertic scraping


### PR DESCRIPTION
Adds option to the values.yaml so that the install can use cert-manager to generate the web-hook certificate

Fixes the issue of the cert not having the the right SANs. See https://github.com/GoogleCloudPlatform/spark-on-k8s-operator/issues/1224, and consider https://github.com/GoogleCloudPlatform/spark-on-k8s-operator/issues/1178 and other issues.

The standard installation uses a script as as init job to generate the certificate secret.  This PR allows
cert-manager to generate the secret instead. In either case, the actual mutating web hook configuration 
is generated in code rather than by helm manifest [?], but the secret is mounted into the pod and read
from the filesystem in any case.
