### PR TITLE
spark-history-server: updated ingress API and spec

### DIFF
--- a/charts/spark-history-server/templates/ingress.yaml
+++ b/charts/spark-history-server/templates/ingress.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullname := include "spark-history-server.fullname" . -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullname }}
@@ -20,18 +20,21 @@ spec:
       http:
         paths:
         - path: {{ $.Values.ingress.path }}
+          pathType: {{ $.Values.ingress.pathType }}
           backend:
-            serviceName: {{ $fullname }}
-            servicePort: {{ $.Values.service.port.number }}
+            service:
+              name: {{ $fullname }}
+              port: 
+                number: {{ $.Values.service.port.number }}
     {{- end -}}
   {{- if .Values.ingress.tls }}
   tls:
   {{- range .Values.ingress.tls }}
-    - hosts:
-      {{- range .hosts }}
-        - {{ . | quote }}
-      {{- end }}
-      secretName: {{ .secretName }}
+  - hosts:
+    {{- range .hosts }}
+      - {{ . | quote }}
+    {{- end }}
+    secretName: {{ .secretName }}
   {{- end }}
 {{- end -}}
 {{- end -}}

--- a/charts/spark-history-server/values.yaml
+++ b/charts/spark-history-server/values.yaml
@@ -53,6 +53,7 @@ ingress:
   # kubernetes.io/ingress.class: nginx
   # kubernetes.io/tls-acme: "true"
   path: /
+  pathType: ImplementationSpecific
   hosts:
     - spark-history-server.example.com
   tls:


### PR DESCRIPTION
This PR addresses API deprecation in k8s version 1.22+ for the ingress object. 