### PR TITLE
ocean-vpa: added option to set  on admission controller pod

### DIFF
--- a/charts/ocean-vpa/Chart.yaml
+++ b/charts/ocean-vpa/Chart.yaml
@@ -17,7 +17,7 @@ maintainers:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.4
+version: 1.0.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/ocean-vpa/README.md
+++ b/charts/ocean-vpa/README.md
@@ -1,6 +1,6 @@
 # ocean-vpa
 
-![Version: 1.0.4](https://img.shields.io/badge/Version-1.0.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.4.1](https://img.shields.io/badge/AppVersion-1.4.1-informational?style=flat-square)
+![Version: 1.0.5](https://img.shields.io/badge/Version-1.0.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.4.1](https://img.shields.io/badge/AppVersion-1.4.1-informational?style=flat-square)
 
 A Helm chart for Kubernetes.
 
@@ -42,6 +42,7 @@ helm install my-release spot/ocean-vpa
 | admissionController.extraArgs.stderrthreshold | string | `"info"` |  |
 | admissionController.extraArgs.v | int | `4` |  |
 | admissionController.generateCertificate | bool | `true` | If true and admissionController is enabled, a pre-install hook will run to create the certificate for the webhook |
+| admissionController.hostNetwork | bool | `false` | Whether to use the host network for the admission controller. This is required in some situations such as when using a custom CNI on EKS. |
 | admissionController.httpPort | int | `8000` | Port of the admission controller for the mutating webhooks |
 | admissionController.image.pullPolicy | string | `"Always"` | The pull policy for the admission controller image. Recommend not changing this |
 | admissionController.image.repository | string | `"registry.k8s.io/autoscaling/vpa-admission-controller"` | The location of the vpa admission controller image |

--- a/charts/ocean-vpa/templates/vpa-admission-controller-deployment.yaml
+++ b/charts/ocean-vpa/templates/vpa-admission-controller-deployment.yaml
@@ -35,6 +35,7 @@ spec:
       serviceAccountName: {{ include "ocean-vpa.serviceAccountName" . }}-admission-controller
       securityContext:
         {{- toYaml .Values.admissionController.podSecurityContext | nindent 8 }}
+      hostNetwork: {{ .Values.admissionController.hostNetwork | default false }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:

--- a/charts/ocean-vpa/values.yaml
+++ b/charts/ocean-vpa/values.yaml
@@ -124,3 +124,6 @@ admissionController:
     feature-gates: InPlaceOrRecreate=true
   # admissionController.httpPort -- Port of the admission controller for the mutating webhooks
   httpPort: 8000
+  # admissionController.hostNetwork -- Whether to use the host network for the admission controller.
+  # This is required in some situations such as when using a custom CNI on EKS.
+  hostNetwork: false


### PR DESCRIPTION
# Demo

_Please add a recording of the feature/bug fix in work. if you added new routes, the recording should show the request and response for each new/changed route_
